### PR TITLE
Fix typo (socket → p)

### DIFF
--- a/src/uWS.cpp
+++ b/src/uWS.cpp
@@ -852,7 +852,7 @@ void Server::onReadable(void *vp, int status, int events)
                                                  socketData->opCode[(unsigned char) socketData->opStack], socketData->fin, socketData->remainingBytes);
 
             // did we close the socket using Socket.fail()?
-            if (uv_is_closing((uv_handle_t *) socket)) {
+            if (uv_is_closing((uv_handle_t *) p)) {
                 return;
             }
 


### PR DESCRIPTION
Socket identifier is `p` not `socket`.