### PR TITLE
Update binding.gyp

### DIFF
--- a/nodejs/dist/binding.gyp
+++ b/nodejs/dist/binding.gyp
@@ -17,9 +17,14 @@
         ['OS=="mac"', {
           'xcode_settings': {
             'MACOSX_DEPLOYMENT_TARGET': '10.7',
-            'OTHER_CFLAGS': [
-              '-std=c++11', '-stdlib=libc++', '-fexceptions'
-            ]
+            'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',
+            'CLANG_CXX_LIBRARY': 'libc++',
+            'GCC_GENERATE_DEBUGGING_SYMBOLS': 'NO',
+            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'GCC_THREADSAFE_STATICS': 'YES',
+            'GCC_OPTIMIZATION_LEVEL': '3',
+            'GCC_ENABLE_CPP_RTTI': 'YES',
+            'OTHER_CFLAGS!': [ '-fno-strict-aliasing' ]
           }
         }],
         ['OS=="win"', {
@@ -47,4 +52,3 @@
     }
   ]
 }
-


### PR DESCRIPTION
This updates the mac condition in binding.gyp as discussed in https://github.com/alexhultman/uWebSockets/commit/d4e56bd1bef6939781d91121832601d5eaba0b24.
This is the list of generated flags:

```
-O3 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++
```