### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/uWS.cpp
+++ b/src/uWS.cpp
@@ -630,7 +630,7 @@ void Server::onAcceptable(void *vp, int status, int events)
 
             // strip away any ? from the GET request
             h.value.first[h.value.second] = 0;
-            for (int i = 0; i < h.value.second; i++) {
+            for (size_t i = 0; i < h.value.second; i++) {
                 if (h.value.first[i] == '?') {
                     h.value.first[i] = 0;
                     break;

--- a/src/uWS.h
+++ b/src/uWS.h
@@ -83,8 +83,8 @@ private:
     void *listenAddr;
     void *loop, *upgradeAsync, *closeAsync;
     void *clients = nullptr;
-    bool forceClose, master;
     int port;
+    bool forceClose, master;
 
     // upgrade queue
     std::queue<std::tuple<FD, std::string, void *>> upgradeQueue;


### PR DESCRIPTION
This fixes some warnings when building with node-gyp on OS X:

```
> node-gyp rebuild

  CXX(target) Release/obj.target/uws/src/uWS.o
../src/uWS.cpp:163:54: warning: field 'port' will be initialized after field 'master' [-Wreorder]
Server::Server(int port, bool master, string path) : port(port), master(master), path(path)
                                                     ^
../src/uWS.cpp:633:31: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
            for (int i = 0; i < h.value.second; i++) {
                            ~ ^ ~~~~~~~~~~~~~~
2 warnings generated.
  CXX(target) Release/obj.target/uws/src/addon.o
  SOLINK_MODULE(target) Release/uws.node
  ACTION binding_gyp_action_after_build_target_move_lib uws
  TOUCH Release/obj.target/action_after_build.stamp
```