### PR TITLE
Spawned Aleph0 monkeys to fix 100% CPU load bug

### DIFF
--- a/src/uWS.cpp
+++ b/src/uWS.cpp
@@ -1234,7 +1234,6 @@ void Socket::close(bool force, unsigned short code, char *data, size_t length)
             delete (uv_poll_t *) handle;
         });
 
-        ::close(fd);
         SSL_free(socketData->ssl);
         socketData->controlBuffer.clear();
 
@@ -1245,6 +1244,7 @@ void Socket::close(bool force, unsigned short code, char *data, size_t length)
                 delete (uv_timer_t *) handle;
             });
         }
+        shutdown(fd, SHUT_WR);
 
         delete socketData;
     } else {


### PR DESCRIPTION
I don't know why this works. Don't ask me.
In any case, it prevents this test npm module: `hog-uws-webkigtk-uv@0.0.2` to get
a 100% CPU load when closing a connection.
