### PR TITLE
fixes an error when sample code is run

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ var io = require('socket.io')(80, { wsEngine: 'uws' });
 ```
 This option has not yet been released, one alternative way of enabling `uws` in current versions of Socket.IO is:
 ```javascript
+var uws = require('uws');
 var io = require('socket.io')(80);
-io.engine.ws = new require('uws').Server({
+io.engine.ws = new uws.Server({
     noServer: true,
     clientTracking: false,
     perMessageDeflate: false


### PR DESCRIPTION
this is the error(node 6.2.0):

TypeError: Class constructor Server cannot be invoked without 'new'
    at RPCserver (/home/capaj/git_projects/zahrajeme.cz-backend/node_modules/socket.io-rpc/main.js:22:37)
    at Object.<anonymous> (/home/capaj/git_projects/zahrajeme.cz-backend/server.js:8:22)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Function.Module.runMain (module.js:575:10)
    at startup (node.js:160:18)
    at node.js:449:3