### PR TITLE
specify os compatibilty in package.json

### DIFF
--- a/nodejs/dist/package.json
+++ b/nodejs/dist/package.json
@@ -9,6 +9,10 @@
   "engines": {
     "node": ">=4"
   },
+  "os": [
+    "darwin",
+    "linux"
+  ],
   "keywords": [
     "websockets",
     "µWS",


### PR DESCRIPTION
This should stop npm from installing a broken module on Windows. The `os` could also be changed to `"os" : [ "!win32" ]` if Solaris and BSD are known to work.