### PR TITLE
Add default value for the `maxPayload` option

### DIFF
--- a/nodejs/dist/uws.js
+++ b/nodejs/dist/uws.js
@@ -215,7 +215,7 @@ class Server extends EventEmitter {
             }
         }
 
-        this.nativeServer = new uws.Server(0, nativeOptions, options.maxPayload);
+        this.nativeServer = new uws.Server(0, nativeOptions, options.maxPayload || 100 * 1024 * 1024);
 
         // can these be made private?
         this._upgradeReq = null;


### PR DESCRIPTION
This adds a default value (100 MiB) for the `maxPayload` option.
This is important becase a large text frame can make the server crash:

```js
'use strict';

const path = require('path');
const fs = require('fs');

const data = fs.readFileSync(path.join(__dirname, '256MiB.txt'));
data.toString();
```

```
buffer.js:528
    throw new Error('"toString()" failed');
    ^

Error: "toString()" failed
    at Buffer.toString (buffer.js:528:11)
    at Object.<anonymous> (/Users/luigi/crash/index.js:7:6)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
    at run (node.js:348:7)
    at startup (node.js:140:9)
```